### PR TITLE
link typo

### DIFF
--- a/papers/KG-domain.md
+++ b/papers/KG-domain.md
@@ -2,7 +2,7 @@
 ### Geospatial Knowledge Graphs
 __Extending the YAGO2 Knowledge Graph with Precise Geospatial Knowledge__. ISWC 2019. _Nikolaos Karalis, Georgios Mandilaras, and Manolis Koubarakis_ [[Paper](http://cgi.di.uoa.gr/~koubarak/publications/2019/yago2geo_iswc2019.pdf)] [[Code](https://github.com/nkaralis/Yago_Extension)]
 
-__Revisiting the Representation of and Need for Raw Geometries on the Linked Data Web__. CEUR Workshop Proceedings. [[Paper](http://ceur-ws.org/Vol-1809/article-04.p)]
+__Revisiting the Representation of and Need for Raw Geometries on the Linked Data Web__. CEUR Workshop Proceedings. [[Paper](http://ceur-ws.org/Vol-1809/article-04.pdf)]
 
 __Design and Development of Linked Data from The National Map__. Semnantic Web Journal. _E. Lynn Usery and Dalia Varanka_ [[Paper](http://www.semantic-web-journal.net/sites/default/files/swj180_2.pdf)]
 


### PR DESCRIPTION
This commit directs the link at the intended location.